### PR TITLE
Adds include for unistd.h on macOS as its required for a successful build.

### DIFF
--- a/gzguts.h
+++ b/gzguts.h
@@ -207,3 +207,7 @@ char ZLIB_INTERNAL *gz_strwinerror OF((DWORD error));
 unsigned ZLIB_INTERNAL gz_intmax OF((void));
 #  define GT_OFF(x) (sizeof(int) == sizeof(z_off64_t) && (x) > gz_intmax())
 #endif
+
+#ifdef __APPLE__
+#include <unistd.h>
+#endif


### PR DESCRIPTION
I cannot confirm is this is because i have a unusual configuration but it shouldn't.
This fixed the build of cuberite for me which failed before because certain sys lib functions like `read`, `write` or `lseek` couldn't be found/defined implicitly 

the exact error, one of them was:
```
/Users/liz3/Desktop/cubrite/cuberite/lib/zlib/gzlib.c:256:24: error: implicit declaration of function 'lseek' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
```
Also see: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/lseek.2.html

macOS: 10.15.7
cmake:  3.17.1

